### PR TITLE
add color as optional input to control current user cursor color

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -53,7 +53,7 @@ export interface Config<T> {
   userMetaData: UserMetadata<T>;
   renderCursor: <T>(cursor: Cursor<T>) => HTMLElement;
   yDoc: Y.Doc;
-  color?: string;
+  color: string;
 }
 
 export const DefaultConfig = {

--- a/src/main.ts
+++ b/src/main.ts
@@ -47,12 +47,13 @@ export function defaultCursorRenderer<T>(cursor: Cursor<T>): HTMLElement {
 }
 
 export interface Config<T> {
-  triggerKey: string,
-  cursorDivId: string,
-  chatDivId: string,
-  userMetaData: UserMetadata<T>,
-  renderCursor: <T>(cursor: Cursor<T>) => HTMLElement,
-  yDoc: Y.Doc,
+  triggerKey: string;
+  cursorDivId: string;
+  chatDivId: string;
+  userMetaData: UserMetadata<T>;
+  renderCursor: <T>(cursor: Cursor<T>) => HTMLElement;
+  yDoc: Y.Doc;
+  color?: string;
 }
 
 export const DefaultConfig = {
@@ -62,7 +63,8 @@ export const DefaultConfig = {
   userMetaData: {},
   renderCursor: defaultCursorRenderer,
   yDoc: undefined,
-}
+  color: undefined,
+};
 
 export const initCursorChat = <T>(
   room_id: string = `cursor-chat-room-${window.location.host + window.location.pathname}`,
@@ -74,6 +76,7 @@ export const initCursorChat = <T>(
     chatDivId,
     userMetaData,
     renderCursor,
+    color,
     yDoc,
   } = {
     ...DefaultConfig,
@@ -92,7 +95,7 @@ export const initCursorChat = <T>(
     x: 0,
     y: 0,
     chat: "",
-    color: randomcolor(),
+    color: color ?? randomcolor(),
     userMetaData,
   }
 


### PR DESCRIPTION
allows consumers to pass in a color for the current user's cursor. This is especially useful when the app has a color that they are assigning to the user and they want cursor chat to match